### PR TITLE
Fix blog typos, alt text, add Jekyll CI

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,0 +1,16 @@
+name: Jekyll Build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - run: bundle exec jekyll build

--- a/_posts/2013-02-06-adaptive-content.md
+++ b/_posts/2013-02-06-adaptive-content.md
@@ -8,7 +8,7 @@ McGrane calls it adaptive content. The goal of this approach is to think of cont
 
 [@studip101](https://twitter.com/studip101)
 
-Metadata describes the structure of content. It tells you what’s important, when it happened, where it happened, and what’s related. Metadata for a blog post might include things like the author, date, tags, and related media. All of this information describes the content without necessarily dictating its appearance. This abstraction allows the same content to be presentented in a variery of ways. Apps and websites that consume the content can use the attached metadata as a guide for how it should be displayed.
+Metadata describes the structure of content. It tells you what’s important, when it happened, where it happened, and what’s related. Metadata for a blog post might include things like the author, date, tags, and related media. All of this information describes the content without necessarily dictating its appearance. This abstraction allows the same content to be presented in a variety of ways. Apps and websites that consume the content can use the attached metadata as a guide for how it should be displayed.
 
 McGrane also suggests that content should be written for reuse. It’s not just about different devices, though. We often want our content to appear on more than one page, on another website, or on social networks like twitter and Facebook. Instead of truncating content to fit, we should offer it in multiple sizes that work in different contexts. An example would be an excerpt that appears in a side bar.
 

--- a/_posts/2014-09-07-using-svg-to-shrink-your-pngs.markdown
+++ b/_posts/2014-09-07-using-svg-to-shrink-your-pngs.markdown
@@ -9,7 +9,7 @@ permalink: how-to-compress-a-png-like-a-jpeg/
 
 Wouldn’t it be great if you could get the compression of a JPEG with the transparency of a PNG? Well, you can, sort of. Here’s a little trick that I discovered while working on the new<a href="http://sapporobeer.ca" target="_blank"> Sapporo Beer website.</a>
 
-![Saporro Beer]({{ site.baseurl }}/images/sapporo.jpg)
+![Sapporo Beer]({{ site.baseurl }}/images/sapporo.jpg)
 
 Notice how the beer can on the Sapporo website has a transparent area around the edges (it’s hard to notice but there’s a video playing behind it). As a PNG, the beer can graphic would have been over 1.2 MB! So how did I get it down to 271KB?
 

--- a/_posts/2019-01-15-blowing-up-images-to-make-them-small.md
+++ b/_posts/2019-01-15-blowing-up-images-to-make-them-small.md
@@ -38,7 +38,7 @@ or as an `<img>` element:
 Here is the result:
 
 <a href="{{ site.baseurl }}/images/32x18.png">
-  <img src="{{ site.baseurl }}/images/32x18.png" style="width: 100%; height auto;" />
+  <img src="{{ site.baseurl }}/images/32x18.png" style="width: 100%; height: auto;" />
 </a>
 `32x18.png (1443 bytes)`
 
@@ -55,7 +55,7 @@ Here is another example:
 Notice how this image has a bit more detail than the previous one. In this case, the small image will need to be a bit larger `(128x72)` to capture the detail. Finding the right size takes some experimenting.
 
 <a href="{{ site.baseurl }}/images/128x72.png">
-  <img src="{{ site.baseurl }}/images/128x72.png" style="width: 100%; height auto;" />
+  <img src="{{ site.baseurl }}/images/128x72.png" style="width: 100%; height: auto;" />
 </a>
 `128x72.png (7 KB)`
 
@@ -67,7 +67,7 @@ This technique is also suitable for blurred background photos — the kind you t
 `1920x1080-4.jpg (199 KB)`
 
 <a href="{{ site.baseurl }}/images/256x144-4.jpg">
-  <img src="{{ site.baseurl }}/images/256x144-4.jpg" style="width: 100%; height auto;" />
+  <img src="{{ site.baseurl }}/images/256x144-4.jpg" style="width: 100%; height: auto;" />
 </a>
 `256x144-4.jpg (10 KB)`
 
@@ -78,7 +78,7 @@ Before you get too excited, this technique does have one limitation. It works we
 <img src="{{ site.baseurl }}/images/1920x1080-3.jpg" />
 `1920x1080-3.jpg (337 KB)`
 
-<img src="{{ site.baseurl }}/images/128x72-2.png" style="width: 100%; height auto;" />
+<img src="{{ site.baseurl }}/images/128x72-2.png" style="width: 100%; height: auto;" />
 `128x72-2.png (21 KB)`
 
 ### What’s going on here?


### PR DESCRIPTION
## Summary
- fix typos in adaptive content post
- fix image style bug
- correct Sapporo alt text
- add GitHub Actions workflow to build Jekyll site

## Testing
- `bundle install` *(fails: 403 Forbidden)*
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b2aaeebe8832b96915fe5043b51b8