### PR TITLE
Move projects section below writing and remove social links

### DIFF
--- a/index.md
+++ b/index.md
@@ -5,21 +5,20 @@ title: "Home"
 # {{ site.description }}
 
 <a href="{{ site.author.github }}">GitHub</a> •
-<a href="{{ site.author.twitter }}">Twitter</a> •
 <a href="{{ site.author.linkedin }}">LinkedIn</a> •
-<a href="{{ site.author.codepen }}">CodePen</a> •
-<a href="{{ site.author.stackoverflow }}">Stackoverflow</a>
+<a href="{{ site.author.codepen }}">CodePen</a>
 
-## Projects
-<ul class="article-list">
-  <li><a href="https://circletype.labwire.ca">CircleType.js</a></li>
-</ul>
 ## Writing
 
 <ul class="article-list" hx-boost="true">
   {% for post in site.posts %}
     <li><a href="{{ post.url }}">{{ post.title }}</a><br>{{ post.date | date_to_string }}</li>
   {% endfor %}
+</ul>
+
+## Projects
+<ul class="article-list">
+  <li><a href="https://circletype.labwire.ca">CircleType.js</a></li>
 </ul>
 
 ![Peter Hrynkow]({{ site.baseurl }}/images/me.jpg){:class="circle-head"}


### PR DESCRIPTION
Reorder homepage to show Writing before Projects. Remove
StackOverflow and Twitter links from the social links bar.

https://claude.ai/code/session_01TfTogtagogQwCwfyNbR699