### PR TITLE
Add border-radius to .highlight wrapper for visible rounded corners

### DIFF
--- a/css/highlight.css
+++ b/css/highlight.css
@@ -1,5 +1,5 @@
 .highlight .hll { background-color: #49483e }
-.highlight  { background: #272822; color: #f8f8f2 }
+.highlight  { background: #272822; color: #f8f8f2; border-radius: 4px; overflow: hidden }
 .highlight .c { color: #75715e } /* Comment */
 .highlight .err { color: #960050; background-color: #1e0010 } /* Error */
 .highlight .k { color: #66d9ef } /* Keyword */


### PR DESCRIPTION
The Jekyll syntax highlighter wraps code blocks in a div.highlight with its own background, which was masking the border-radius on the inner pre element.

https://claude.ai/code/session_01M6RQgt7uxLRmipCDEbZWEL