### PR TITLE
Fix code block border-radius by targeting .highlighter-rouge wrapper

### DIFF
--- a/css/highlight.css
+++ b/css/highlight.css
@@ -1,5 +1,5 @@
 .highlight .hll { background-color: #49483e }
-.highlight  { background: #272822; color: #f8f8f2; border-radius: 4px; overflow: hidden }
+.highlight  { background: #272822; color: #f8f8f2 }
 .highlight .c { color: #75715e } /* Comment */
 .highlight .err { color: #960050; background-color: #1e0010 } /* Error */
 .highlight .k { color: #66d9ef } /* Keyword */

--- a/css/peterhry.css
+++ b/css/peterhry.css
@@ -126,11 +126,15 @@ img {
   max-width: 100%;
 }
 
+.highlighter-rouge {
+  border-radius: 4px;
+  overflow: hidden;
+}
+
 pre {
   -webkit-overflow-scrolling: touch;
   overflow: auto;
   padding: 1rem;
-  border-radius: 4px;
 }
 
 code {


### PR DESCRIPTION
Rouge generates .highlight on both the wrapper div AND the inner pre, so applying border-radius/overflow there caused conflicts. Instead, target .highlighter-rouge which only exists on the outermost div, keeping pre free to scroll with overflow: auto.

https://claude.ai/code/session_01M6RQgt7uxLRmipCDEbZWEL